### PR TITLE
Change track resume behavior

### DIFF
--- a/src/js/dev/player/player.js
+++ b/src/js/dev/player/player.js
@@ -47,6 +47,7 @@ function toggleTrackPlaying(playCb, pauseCb) {
     const paused = settings.get("paused");
 
     if (paused) {
+        settings.set("manual", true);
         playCb();
     }
     else {


### PR DESCRIPTION
Should no longer scroll track into view on player resume.